### PR TITLE
Fixed a bug where the message "remove:" was sent instead of "remove: ifAbsent:"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Bash needs lf even on windows/cygwin
+*.st eol=lf
+*.sh eol=lf
+
+# st files are always text, even if they contain invalid encoded chars
+*.st text diff
+
+# GitHub is unable to properly detect Smalltalk code, so help it a bit
+*.st linguist-language=Smalltalk

--- a/tonel/AbstractGPU-CorePharo/AGPUInterface.class.st
+++ b/tonel/AbstractGPU-CorePharo/AGPUInterface.class.st
@@ -51,7 +51,7 @@ AGPUInterface >> isNull [
 
 { #category : #finalization }
 AGPUInterface >> release [
-	self class finalizationRegistry remove: self.
+	self class finalizationRegistry remove: self ifAbsent: [].
 	self primitiveRelease.
 	handle := nil.
 ]


### PR DESCRIPTION
The message "remove:" was sent instead of "remove: ifAbsent:" to a FinalizationRegistry Object.

![debug](https://user-images.githubusercontent.com/58030198/228223745-437084b5-1011-4f9f-ad0e-95639cd35e6f.png)

![FinalizationRegistry](https://user-images.githubusercontent.com/58030198/228223790-962ed601-ea44-4d88-a616-ffc7e7a81a42.png)

This led Woden Applications to crash when opened in OS Window and trying to resize the window.